### PR TITLE
Publish as UMD and es2015

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-plugin-array-includes": "^2.0.3",
     "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "browser-env": "^2.0.19",
+    "camelcase": "^4.0.0",
     "coveralls": "^2.11.15",
     "jsdom": "^9.9.1",
     "nyc": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,12 @@
   "name": "when-dom-ready",
   "version": "1.2.5",
   "description": "$(document).ready() for the 21st century",
-  "main": "dist/index.js",
+  "main": "dist/index.umd.js",
+  "module": "dist/index.es2015.js",
   "scripts": {
     "prebuild": "rm -rf dist",
-    "build": "babel -d dist src",
-    "prebuild:map": "npm run prebuild",
-    "build:map": "babel --source-maps=true -d dist src",
-    "pretest": "npm run build:map",
+    "build": "rollup -c",
+    "pretest": "npm run build",
     "lint": "xo",
     "test": "nyc ava",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
@@ -51,13 +50,14 @@
   "dependencies": {},
   "devDependencies": {
     "ava": "^0.17.0",
-    "babel-cli": "^6.22.2",
     "babel-plugin-array-includes": "^2.0.3",
     "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "browser-env": "^2.0.19",
     "coveralls": "^2.11.15",
     "jsdom": "^9.9.1",
     "nyc": "^10.0.0",
+    "rollup": "^0.41.4",
+    "rollup-plugin-babel": "^2.7.1",
     "xo": "^0.17.1"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import babel from 'rollup-plugin-babel';
+import camelCase from 'camelcase';
 
 const pkg = require('./package.json');
 
@@ -11,7 +12,7 @@ export default {
     {
       dest: pkg.main,
       format: 'umd',
-      moduleName: 'whenDomReady',
+      moduleName: camelCase(pkg.name),
       sourceMap: true
     },
     {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,23 @@
+import babel from 'rollup-plugin-babel';
+
+const pkg = require('./package.json');
+
+export default {
+  entry: 'src/index.js',
+  plugins: [
+    babel(),
+  ],
+  targets: [
+    {
+      dest: pkg.main,
+      format: 'umd',
+      moduleName: 'whenDomReady',
+      sourceMap: true
+    },
+    {
+      dest: pkg.module,
+      format: 'es',
+      sourceMap: true
+    }
+  ]
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,21 +4,21 @@ import camelCase from 'camelcase';
 const pkg = require('./package.json');
 
 export default {
-  entry: 'src/index.js',
-  plugins: [
-    babel(),
-  ],
-  targets: [
-    {
-      dest: pkg.main,
-      format: 'umd',
-      moduleName: camelCase(pkg.name),
-      sourceMap: true
-    },
-    {
-      dest: pkg.module,
-      format: 'es',
-      sourceMap: true
-    }
-  ]
+	entry: 'src/index.js',
+	plugins: [
+		babel()
+	],
+	targets: [
+		{
+			dest: pkg.main,
+			format: 'umd',
+			moduleName: camelCase(pkg.name),
+			sourceMap: true
+		},
+		{
+			dest: pkg.module,
+			format: 'es',
+			sourceMap: true
+		}
+	]
 };

--- a/src/index.js
+++ b/src/index.js
@@ -27,4 +27,4 @@ const whenDomReady = (cb, doc) => new Promise(resolve => {
 // Promise chain helper
 whenDomReady.resume = doc => val => whenDomReady(doc).then(() => val);
 
-module.exports = whenDomReady;
+export default whenDomReady;


### PR DESCRIPTION
Instead of CommonJS publish as UMD and es2015 so we can support browser global and AMD loading as well as es2015 module loaders with the `module` field in `package.json`